### PR TITLE
Fix mime dependency

### DIFF
--- a/lib/express-negotiate.js
+++ b/lib/express-negotiate.js
@@ -107,7 +107,9 @@ request.negotiate = function(format, next, handlers) {
 
 function lookup_type(type) {
     if (type && !~type.indexOf('/'))
-        type = mime.lookup(type);
+        // for unknown types application/octet-stream is returned to maintain
+        // the behaviour of the old mime.lookup (mime < 2.0.0)
+        type = mime.getType(type) || 'application/octet-stream';
     return type;
 }
 

--- a/lib/express-negotiate.js
+++ b/lib/express-negotiate.js
@@ -9,7 +9,7 @@
 /**
  * Library version.
  */
-exports.version = '0.0.4';
+exports.version = '0.0.5';
 
 
 /**

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   , "keywords": ["express"]
   , "author": "Chris Leishman <chris@leishman.org>"
   , "dependencies": {
-      "mime": ">= 0.0.1"
+      "mime": "^2.3.1"
   }
   , "devDependencies": {
       "should": "0.6.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "express-negotiate"
-  , "version": "0.0.4"
+  , "version": "0.0.5"
   , "description": "Express content negotiation functions"
   , "keywords": ["express"]
   , "author": "Chris Leishman <chris@leishman.org>"


### PR DESCRIPTION
Hi,

I noticed that `mime.lookup()` changed to `mime.getType()` in v2, which broke this module. This PR fixes the relevant call and updates the mime dependency, now capped to major version 2.

I also upped the version from 0.0.4 to 0.0.5, although according to npm this is supposed to be at 0.0.5 already? I don't know what's up with that.